### PR TITLE
Add ability to construct PrivateKey from string

### DIFF
--- a/src/buddy/core/keys.clj
+++ b/src/buddy/core/keys.clj
@@ -89,6 +89,13 @@
   (with-open [reader (StringReader. ^String keydata)]
     (read-pem->pubkey reader)))
 
+(defn str->private-key
+  "Private key constructor from string."
+  [keydata]
+  (with-open [reader (StringReader. ^String keydata)]
+   (let [keypair (read-pem->keypair reader nil)]
+     (.getPrivate keypair))))
+
 (defn public-key?
   "Return true if key `k` is a public key."
   [k]

--- a/src/buddy/core/keys.clj
+++ b/src/buddy/core/keys.clj
@@ -91,10 +91,12 @@
 
 (defn str->private-key
   "Private key constructor from string."
-  [keydata]
+  ([keydata]
+   (str->private-key keydata nil))
+  ([keydata passphrase]
   (with-open [reader (StringReader. ^String keydata)]
-   (let [keypair (read-pem->keypair reader nil)]
-     (.getPrivate keypair))))
+   (let [keypair (read-pem->keypair reader passphrase)]
+     (.getPrivate keypair)))))
 
 (defn public-key?
   "Return true if key `k` is a public key."

--- a/test/buddy/core/keys_tests.clj
+++ b/test/buddy/core/keys_tests.clj
@@ -72,7 +72,7 @@
       (is (keys/private-key? pkey))))
 
   (testing "Read rsa priv key from string"
-    (let [keystr (slurp "test/_files/privkey.rsa.pem")
+    (let [keystr (slurp "test/_files/privkey.3des.rsa.pem")
           pkey (keys/str->private-key keystr "secret")]
       (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey))
       (is (keys/private-key? pkey))))

--- a/test/buddy/core/keys_tests.clj
+++ b/test/buddy/core/keys_tests.clj
@@ -64,7 +64,19 @@
           pkey (keys/str->public-key keystr)]
       (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey))
       (is (keys/public-key? pkey))))
-  )
+
+  (testing "Read ecdsa priv key from string."
+    (let [keystr (slurp "test/_files/privkey.ecdsa.pem")
+          pkey (keys/str->private-key keystr)]
+      (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey))
+      (is (keys/private-key? pkey))))
+
+    (testing "Read rsa priv key from string."
+    (let [keystr (slurp "test/_files/privkey.rsa.pem")
+          pkey (keys/str->private-key keystr)]
+      (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey))
+      (is (keys/private-key? pkey))))
+)
 
 (deftest key-wrapping-algorithms
   (let [secret16 (nonce/random-bytes 16)

--- a/test/buddy/core/keys_tests.clj
+++ b/test/buddy/core/keys_tests.clj
@@ -71,11 +71,26 @@
       (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey))
       (is (keys/private-key? pkey))))
 
-    (testing "Read rsa priv key from string."
+  (testing "Read rsa priv key from string"
+    (let [keystr (slurp "test/_files/privkey.rsa.pem")
+          pkey (keys/str->private-key keystr "secret")]
+      (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey))
+      (is (keys/private-key? pkey))))
+
+  (testing "Read rsa priv key from string without password."
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (let [keystr (slurp "test/_files/privkey.3des.rsa.pem")
+                       pkey (keys/str->private-key keystr)])))
     (let [keystr (slurp "test/_files/privkey.rsa.pem")
           pkey (keys/str->private-key keystr)]
       (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey))
       (is (keys/private-key? pkey))))
+
+  (testing "Read rsa priv key from string with bad password"
+    (is (thrown? org.bouncycastle.openssl.EncryptionException
+                 (let [keystr (slurp "test/_files/privkey.3des.rsa.pem")
+                       pkey (keys/str->private-key keystr "secret2")]
+                   (is (= (type pkey) org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey))))))
 )
 
 (deftest key-wrapping-algorithms


### PR DESCRIPTION
I have a project where I am generating private keys as strings but don't write them to files.

For this, I added a variable arity keys/str->private-key function to construct PrivateKey objects similar to the existing keys/str->public-key functions that create PublicKey objects.

Comments welcome!
