### PR TITLE
Do not deprecate hash/sha1 and hash/md5

### DIFF
--- a/src/buddy/core/hash.clj
+++ b/src/buddy/core/hash.clj
@@ -241,11 +241,9 @@
   (digest input :sha3-512))
 
 (defn sha1
-  {:deprecated true}
   [input]
   (digest input :sha1))
 
 (defn md5
-  {:deprecated true}
   [input]
   (digest input :md5))


### PR DESCRIPTION
SHA1 and MD5 algorithms are deprecated, but the functions are not: they
will be used for a long time for maintaining compatibility with obsolete
data formats and protocols (See #22)