### PR TITLE
Fix the reference warning for buddy.core.bytes/bytes?

### DIFF
--- a/src/buddy/core/bytes.clj
+++ b/src/buddy/core/bytes.clj
@@ -15,7 +15,7 @@
 (ns buddy.core.bytes
   "A collection of functions for work with byte arrays
   and bytes."
-  (:refer-clojure :exclude [concat])
+  (:refer-clojure :exclude [bytes? concat])
   (:import java.nio.ByteBuffer
            java.util.Arrays))
 


### PR DESCRIPTION
WARNING: bytes? already refers to: #'clojure.core/bytes? in namespace: buddy.core.bytes, being replaced by: #'buddy.core.bytes/bytes?