### PR TITLE
remove bouncycastle from jar because it causes signature errors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,11 @@
-(defproject buddy/buddy-core "1.1.1"
+(defproject buddy/buddy-core "1.1.2-SNAPSHOT"
   :description "Cryptographic Api for Clojure."
   :url "https://github.com/funcool/buddy-core"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha13" :scope "provided"]
                  [org.clojure/test.check "0.9.0" :scope "test"]
-                 [commons-codec/commons-codec "1.10"]
-                 [org.bouncycastle/bcprov-jdk15on "1.55"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.55"]]
+                 [commons-codec/commons-codec "1.10"]]
   :source-paths ["src"]
   :test-paths ["test"]
   :jar-exclusions [#"\.cljx|\.swp|\.swo|user.clj"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kixi/buddy-core "1.1.2-SNAPSHOT"
+(defproject kixi/buddy-core "1.1.2"
   :description "Cryptographic Api for Clojure."
   :url "https://github.com/funcool/buddy-core"
   :license {:name "Apache 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject buddy/buddy-core "1.1.2-SNAPSHOT"
+(defproject kixi/buddy-core "1.1.2-SNAPSHOT"
   :description "Cryptographic Api for Clojure."
   :url "https://github.com/funcool/buddy-core"
   :license {:name "Apache 2.0"


### PR DESCRIPTION
Just in case, for issue https://github.com/funcool/buddy-core/issues/43
Not sure how to solve the fact that the bouncycastle jars have to be in the classpath somewhere.