### PR TITLE
Closes the file automatically after digesting it

### DIFF
--- a/src/buddy/core/hash.clj
+++ b/src/buddy/core/hash.clj
@@ -149,7 +149,8 @@
 
   java.io.File
   (-digest [^java.io.File input engine]
-    (hash-stream-data (io/input-stream input) engine))
+    (with-open [is (io/input-stream input)]
+      (hash-stream-data is engine)))
 
   java.net.URL
   (-digest [^java.net.URL input engine]


### PR DESCRIPTION
When we hash a file, normally we expect it will be closed automatically by the hash function. So i think it's better to close the file automatically after digesting it using the IDigest protocol.