### PR TITLE
Reflection fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,11 @@
                  [org.clojure/test.check "0.9.0" :scope "test"]
                  [commons-codec/commons-codec "1.10"]
                  [org.bouncycastle/bcprov-jdk15on "1.58"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.58"]]
+                 [org.bouncycastle/bcpkix-jdk15on "1.58"]
+                 [org.clojure/tools.namespace "0.2.11"]]
   :source-paths ["src"]
   :test-paths ["test"]
+  :global-vars {*warn-on-reflection* true}
   :jar-exclusions [#"\.cljx|\.swp|\.swo|user.clj"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"])
 

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,7 @@
                  [org.clojure/test.check "0.9.0" :scope "test"]
                  [commons-codec/commons-codec "1.10"]
                  [org.bouncycastle/bcprov-jdk15on "1.58"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.58"]
-                 [org.clojure/tools.namespace "0.2.11"]]
+                 [org.bouncycastle/bcpkix-jdk15on "1.58"]]
   :source-paths ["src"]
   :test-paths ["test"]
   :global-vars {*warn-on-reflection* true}

--- a/src/buddy/core/bytes.clj
+++ b/src/buddy/core/bytes.clj
@@ -28,7 +28,7 @@
   [x]
   (if (nil? x)
     false
-    (= +bytes-class+ (.getClass x))))
+    (= +bytes-class+ (.getClass ^Object x))))
 
 (defn fill!
   "Assigns the specified byte value to each element
@@ -38,7 +38,7 @@
   ([^bytes input val & {:keys [limit offset start end]}]
    (let [start (or offset start 0)
          end (or limit start (count input))]
-     (Arrays/fill input start end (byte val)))))
+     (Arrays/fill input ^int start ^int end (byte val)))))
 
 (defn slice
   "Returns a new copy of the byte array but

--- a/src/buddy/core/certificates.clj
+++ b/src/buddy/core/certificates.clj
@@ -11,11 +11,16 @@
   (Security/addProvider (org.bouncycastle.jce.provider.BouncyCastleProvider.)))
 
 (defn- public-key-verifier
-  [^X509CertificateHolder pub-key]
-  (.build
-   (doto (JcaContentVerifierProviderBuilder.)
-     (.setProvider "BC"))
-   pub-key))
+  [pub-key]
+  (let [builder (doto (JcaContentVerifierProviderBuilder.)
+                      (.setProvider "BC"))]
+    (cond
+      (instance? X509CertificateHolder pub-key)
+        (.build builder ^X509CertificateHolder pub-key)
+      (instance? PublicKey pub-key)
+        (.build builder ^PublicKey pub-key)
+      :else
+        (throw (Exception. "Unknown public key type" {:kind (class pub-key)})))))
 
 (defn certificate
   "Reads a certificate from a PEM encoded file or stream"

--- a/src/buddy/core/certificates.clj
+++ b/src/buddy/core/certificates.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io])
   (:import java.io.StringReader
            java.security.Security
+           java.security.PublicKey
            org.bouncycastle.openssl.PEMParser
            org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder
            org.bouncycastle.cert.X509CertificateHolder))
@@ -10,7 +11,7 @@
   (Security/addProvider (org.bouncycastle.jce.provider.BouncyCastleProvider.)))
 
 (defn- public-key-verifier
-  [pub-key]
+  [^X509CertificateHolder pub-key]
   (.build
    (doto (JcaContentVerifierProviderBuilder.)
      (.setProvider "BC"))
@@ -26,24 +27,24 @@
 
 (defn not-after
   "Returns the last date this signature is valid."
-  [cert]
+  [^X509CertificateHolder cert]
   (.getNotAfter cert))
 
 (defn not-before
   "Returns the first date this certificate is valid."
-  [cert]
+  [^X509CertificateHolder cert]
   (.getNotAfter cert))
 
 (defn valid-on-date?
   "Returns true if certificate is valid date. Defaults to today"
-  ([certificate date]
+  ([^X509CertificateHolder certificate date]
    (.isValidOn certificate date))
-  ([certificate]
+  ([^X509CertificateHolder certificate]
    (valid-on-date? certificate (java.util.Date.))))
 
 (defn subject
   "Returns the subject of the certificate"
-  [cert]
+  [^X509CertificateHolder cert]
   (.toString (.getSubject cert)))
 
 (defn str->certificate
@@ -54,7 +55,7 @@
 
 (defn verify-signature
   "Verifies that the certificate is signed with the provided public key."
-  [cert public-key]
+  [^X509CertificateHolder cert public-key]
   (.isSignatureValid cert (public-key-verifier public-key)))
 
 (defn certificate?

--- a/src/buddy/core/crypto.clj
+++ b/src/buddy/core/crypto.clj
@@ -42,7 +42,7 @@
 ;; --- Constants
 
 (def ^:no-doc
-  +block-cipher-engines+
+  ^BlockCipher +block-cipher-engines+
   {:aes     #(AESFastEngine.)
    :serpent #(SerpentEngine.)
    :twofish #(TwofishEngine.)})
@@ -52,13 +52,13 @@
   {:chacha #(ChaChaEngine.)})
 
 (def ^:no-doc
-  +cipher-modes+
+  ^BlockCipher +cipher-modes+
   {:ecb #(identity %)
    :cbc #(CBCBlockCipher. %)
    :gcm #(GCMBlockCipher. %)
    :ctr #(SICBlockCipher. %)
    :sic #(SICBlockCipher. %)
-   :ofb #(OFBBlockCipher. % (* 8 (.getBlockSize %)))})
+   :ofb #(OFBBlockCipher. % (* 8 (.getBlockSize ^BlockCipher %)))})
 
 ;; --- Implementation details.
 
@@ -167,11 +167,11 @@
     (.processBlock ^BlockCipher e in inoff out outoff))
 
   AEADBlockCipher
-  (-process-block [e in inoff out outoff]
+  (-process-block [e ^bytes in inoff out outoff]
     (.processBytes ^AEADBlockCipher e in (int inoff) (alength in) out (int outoff)))
 
   StreamCipher
-  (-process-block [e in inoff out outoff]
+  (-process-block [e ^bytes in inoff out outoff]
     (.processBytes ^StreamCipher e in (int inoff) (alength in) out (int outoff))))
 
 (extend-protocol IStreamCipherLike
@@ -198,12 +198,12 @@
   "Encrypt or decrypt a bytes using the specified engine.
   Is a specialized version of `process-block!` for stream ciphers
   and aead ciphers."
-  ([engine in]
+  ([engine ^bytes in]
    (let [length (alength in)
          out (byte-array length)]
      (-process-bytes engine in 0 length out 0)
      out))
-  ([engine in inoff out outoff]
+  ([engine ^bytes in inoff out outoff]
    (-process-bytes engine in inoff (alength in) out outoff))
   ([engine in inoff inlen out outoff]
    (-process-bytes engine in inoff inlen out outoff)))

--- a/src/buddy/core/crypto.clj
+++ b/src/buddy/core/crypto.clj
@@ -42,7 +42,7 @@
 ;; --- Constants
 
 (def ^:no-doc
-  ^BlockCipher +block-cipher-engines+
+  +block-cipher-engines+
   {:aes     #(AESFastEngine.)
    :serpent #(SerpentEngine.)
    :twofish #(TwofishEngine.)})
@@ -52,7 +52,7 @@
   {:chacha #(ChaChaEngine.)})
 
 (def ^:no-doc
-  ^BlockCipher +cipher-modes+
+  +cipher-modes+
   {:ecb #(identity %)
    :cbc #(CBCBlockCipher. %)
    :gcm #(GCMBlockCipher. %)

--- a/src/buddy/core/dsa.clj
+++ b/src/buddy/core/dsa.clj
@@ -67,7 +67,7 @@
   Signature
   (-init [^Signature it options]
     (let [verify? (:verify options false)
-          key (:key options)]
+          ^PublicKey key (:key options)]
       (if verify?
         (.initVerify it key)
         (let [prng (or (:prng options)

--- a/src/buddy/core/kdf.clj
+++ b/src/buddy/core/kdf.clj
@@ -27,6 +27,7 @@
            org.bouncycastle.crypto.params.KDFCounterParameters
            org.bouncycastle.crypto.params.KDFFeedbackParameters
            org.bouncycastle.crypto.params.KDFDoublePipelineIterationParameters
+           org.bouncycastle.crypto.params.KeyParameter
            org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
            org.bouncycastle.crypto.macs.HMac
            org.bouncycastle.crypto.DerivationFunction
@@ -77,7 +78,7 @@
 (extend-protocol IKDF
   PKCS5S2ParametersGenerator
   (-get-bytes [it length]
-    (.getKey (.generateDerivedParameters it (* 8 length)))))
+    (.getKey ^KeyParameter (.generateDerivedParameters it (* 8 length)))))
 
 (defmethod engine :hkdf
   [{:keys [key salt info digest]}]

--- a/src/buddy/core/keys/pem.clj
+++ b/src/buddy/core/keys/pem.clj
@@ -33,10 +33,10 @@
   (Security/addProvider (org.bouncycastle.jce.provider.BouncyCastleProvider.)))
 
 (defn- decryptor
-  [builder passphrase]
+  [^String passphrase]
   (when (nil? passphrase)
     (throw (ex-info "Passphrase is mandatory with encrypted keys." {})))
-  (.build builder (.toCharArray passphrase)))
+  (.toCharArray passphrase))
 
 ;; TODO: maybe make this functions work with strings instead of reader
 
@@ -49,14 +49,14 @@
                       (.setProvider "BC"))]
       (cond
         (instance? PEMEncryptedKeyPair obj)
-        (->> (.decryptKeyPair obj (decryptor (JcePEMDecryptorProviderBuilder.) passphrase))
+        (->> (.decryptKeyPair ^PEMEncryptedKeyPair obj (.build (JcePEMDecryptorProviderBuilder.) (decryptor passphrase)))
              (.getKeyPair converter)
              (.getPrivate))
         (instance? PEMKeyPair obj)
         (->> (.getKeyPair converter obj)
              (.getPrivate))
         (instance? PKCS8EncryptedPrivateKeyInfo obj)
-        (->> (.decryptPrivateKeyInfo obj (decryptor (JceOpenSSLPKCS8DecryptorProviderBuilder.) passphrase))
+        (->> (.decryptPrivateKeyInfo ^PKCS8EncryptedPrivateKeyInfo obj (.build (JceOpenSSLPKCS8DecryptorProviderBuilder.) (decryptor passphrase)))
              (.getPrivateKey converter))
         (instance? PrivateKeyInfo obj)
         (.getPrivateKey converter obj)
@@ -71,6 +71,6 @@
           converter (doto (JcaPEMKeyConverter.)
                       (.setProvider "BC"))]
       (if (instance? X509CertificateHolder keyinfo)
-        (.getPublicKey converter (.getSubjectPublicKeyInfo keyinfo))
+        (.getPublicKey converter (.getSubjectPublicKeyInfo ^X509CertificateHolder keyinfo))
         (.getPublicKey converter keyinfo)))))
 

--- a/src/buddy/core/nonce.clj
+++ b/src/buddy/core/nonce.clj
@@ -25,7 +25,7 @@
 
 
 (defn random-bytes
-  "Generate a byte array of scpecified length with random
+  "Generate a byte array of specified length with random
   bytes taken from secure random number generator.
   This method should be used to generate a random
   iv/salt or arbitrary length."
@@ -46,7 +46,7 @@
   ([^long numbytes ^SecureRandom sr]
    (let [buffer (java.nio.ByteBuffer/allocate numbytes)]
      (.putLong buffer (System/currentTimeMillis))
-     (.put buffer (random-bytes (.remaining buffer) sr))
+     (.put buffer ^bytes (random-bytes (.remaining buffer) sr))
      (.array buffer))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/buddy/core/nonce.clj
+++ b/src/buddy/core/nonce.clj
@@ -56,5 +56,5 @@
 (defmulti for-engine class)
 
 (defmethod for-engine ChaChaEngine [e] (random-nonce 8))
-(defmethod for-engine SICBlockCipher [e] (random-nonce (.getBlockSize e)))
-(defmethod for-engine BlockCipher [e] (random-bytes (.getBlockSize e)))
+(defmethod for-engine SICBlockCipher [^BlockCipher e] (random-nonce (.getBlockSize e)))
+(defmethod for-engine BlockCipher [^BlockCipher e] (random-bytes (.getBlockSize e)))

--- a/src/buddy/core/padding.clj
+++ b/src/buddy/core/padding.clj
@@ -16,7 +16,8 @@
   "Block padding algorithms."
   (:refer-clojure :exclude [count])
   (:require [buddy.core.bytes :as bytes])
-  (:import org.bouncycastle.crypto.paddings.ZeroBytePadding
+  (:import org.bouncycastle.crypto.paddings.BlockCipherPadding
+           org.bouncycastle.crypto.paddings.ZeroBytePadding
            org.bouncycastle.crypto.paddings.X923Padding
            org.bouncycastle.crypto.paddings.PKCS7Padding
            org.bouncycastle.crypto.paddings.TBCPadding
@@ -26,7 +27,7 @@
 
 (defn padding-engine
   "Create a padding enginde for given algorithm name."
-  [^Keyword alg]
+  ^BlockCipherPadding [^Keyword alg]
   (condp = alg
     :zerobyte (ZeroBytePadding.)
     :pkcs7 (PKCS7Padding.)


### PR DESCRIPTION
This PR enables "\*warn-on-reflection\*" and fixes all the reflection warnings I found as a result. I've run the test suite locally, and haven't hit any issues, but there could potentially still be regression issues if someone's calling something with a class I haven't hit during my testing.