### PR TITLE
Remove :doc false since there is a doc string

### DIFF
--- a/src/buddy/core/hash.clj
+++ b/src/buddy/core/hash.clj
@@ -104,7 +104,6 @@
 (defn resolve-digest-engine
   "Helper function for make Digest instances
   from algorithm parameter."
-  {:doc false}
   [engine]
   (cond
    (keyword? engine)

--- a/src/buddy/core/mac.clj
+++ b/src/buddy/core/mac.clj
@@ -67,7 +67,6 @@
   "Given dynamic type engine, try resolve it to
   valid engine instance. By default accepts keywords
   and functions."
-  {:doc false}
   [engine]
   (cond
     (keyword? engine)


### PR DESCRIPTION
Hi there! Thank you for this excellent library! 
I just came across this over [here](https://github.com/cljdoc/cljdoc/pull/285) and was wondering if there is any reason behind having a docstring plus `{:doc false}` metadata. If this is simply some left over, I'm happy to have this merged. Otherwise feel free to close this MR. Thanks :)