### PR TITLE
add secp256k1 (used in bitcoin) elliptic curve support

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -327,7 +327,7 @@ Currently supported JWK key types are
 
 * RSA key pairs (No RSA-CRT support yet)
 * OKP key pairs (Ed25519)
-* EC key pairs (P-256, P-384, P-521 curves)
+* EC key pairs (P-256, secp256k1, P-384, P-521 curves)
 
 Example of JWS signing for Ed25519 keys
 

--- a/src/buddy/core/keys/jwk/ec.clj
+++ b/src/buddy/core/keys/jwk/ec.clj
@@ -62,6 +62,14 @@
   [jwk]
   (load-public jwk "P-256"))
 
+(defmethod jwkec->private-key "secp256k1"
+  [jwk]
+  (load-private jwk "secp256k1"))
+
+(defmethod jwkec->public-key "secp256k1"
+  [jwk]
+  (load-public jwk "secp256k1"))
+
 (defmethod jwkec->private-key "P-384"
   [jwk]
   (load-private jwk "P-384"))
@@ -91,12 +99,14 @@
     (condp = curve
       (get-curve "P-256")
       "P-256"
+      (get-curve "secp256k1")
+      "secp256k1"
       (get-curve "P-384")
       "P-384"
       (get-curve "P-521")
       "P-521"
       ;; default
-      (throw (ex-info "Unsupported EC curve (only P-256, P-384 and P-521 supported)"
+      (throw (ex-info "Unsupported EC curve (only P-256, secp256k1, P-384 and P-521 supported)"
                       {:key key})))))
 
 (defn- convert-public [^ECPublicKey public]


### PR DESCRIPTION
This does not create any incompatibilities, since `secp256k1` differs from `P-256` (aka `secp256r1` where `r` is from `random`) with different `a` (0) and `b` (7) coefficients.