### PR TITLE
Bump cheshire dependency to 5.10.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
                  [org.clojure/test.check "1.1.0" :scope "test"]
                  [commons-codec/commons-codec "1.15"]
-                 [cheshire "5.10.0"]
+                 [cheshire "5.10.1"]
                  [org.bouncycastle/bcprov-jdk15on "1.68"]
                  [org.bouncycastle/bcpkix-jdk15on "1.68"]]
   :jar-name "buddy-core.jar"


### PR DESCRIPTION
This release of cheshire bumps the transitive dependency:

`com.fasterxml.jackson.dataformat/jackson-dataformat-cbor`

Which includes a fix for CVE-2020-28491

Note at the time of writing this commit the cheshire release notes do
not contain information on this release.  However I have run lein nvd
on the appropriate commits in cheshire to confirm the problematic
dependency is no longer present in this cheshire release.

https://github.com/dakrone/cheshire/commit/a69ee9513a87fda3fb9bd454d256f37ec5961a86