### PR TITLE
Updates bouncycastle deps to 1.78

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:deps
  {commons-codec/commons-codec {:mvn/version "1.16.0"}
   cheshire/cheshire {:mvn/version "5.11.0"}
-  org.bouncycastle/bcprov-jdk18on {:mvn/version "1.75"}
-  org.bouncycastle/bcpkix-jdk18on {:mvn/version "1.75"}}
+  org.bouncycastle/bcprov-jdk18on {:mvn/version "1.78"}
+  org.bouncycastle/bcpkix-jdk18on {:mvn/version "1.78"}}
  :paths ["src" "resources" "target/classes"]
  :aliases
  {:dev


### PR DESCRIPTION
This PR bumps `org.bouncycastle/bcpkix-jdk18on` and `org.bouncycastle/bcprov-jdk18on` dependencies to `1.78`.

This includes a fix for CVE-2024-29857 #79 